### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 6.0 (unreleased)
 ================
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Drop support for Python 3.8.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-5.2 (unreleased)
+6.0 (unreleased)
 ================
 
 - Drop support for Python 3.8.

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ TESTS_REQUIRE = [
 
 setup(
     name='zope.principalannotation',
-    version='5.2.dev0',
+    version='6.0.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
     description='Annotations for Zope Principals',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -28,7 +27,7 @@ TESTS_REQUIRE = [
     'zope.configuration',
     'zope.testing',
     'zope.site[test]',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
 ]
 
 setup(
@@ -64,9 +63,6 @@ setup(
     ],
     url='https://github.com/zopefoundation/zope.principalannotation',
     license='ZPL-2.1',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['zope'],
     python_requires='>=3.9',
     extras_require={
         'test': TESTS_REQUIRE,

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
